### PR TITLE
Mopidy 1.0 compat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,11 @@ Project resources
 Changelog
 =========
 
+v0.2.0 (UNRELEASED)
+-------------------
+
+- Require Mopidy >= 1.0
+
 v0.1.0 (2014-09-27)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,8 @@ v0.2.0 (UNRELEASED)
 
 - Require Mopidy >= 1.0
 
+- Update to work with changed backend APIs in Mopidy 1.0
+
 v0.1.0 (2014-09-27)
 -------------------
 

--- a/mopidy_oe1/__init__.py
+++ b/mopidy_oe1/__init__.py
@@ -6,7 +6,7 @@ import os
 from mopidy import config, ext
 
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy_oe1/library.py
+++ b/mopidy_oe1/library.py
@@ -64,9 +64,6 @@ class OE1LibraryProvider(backend.LibraryProvider):
                           name=self._get_track_title(item))
                 for item in self.client.get_day(day_id)['items']]
 
-    def find_exact(self, query=None, uris=None):
-        return []
-
     def lookup(self, uri):
         try:
             library_uri = OE1LibraryUri.parse(uri)
@@ -101,9 +98,6 @@ class OE1LibraryProvider(backend.LibraryProvider):
 
     def refresh(self, uri=None):
         self.client.refresh()
-
-    def search(self, query=None, uris=None):
-        return []
 
 
 class OE1LibraryUri(object):

--- a/mopidy_oe1/playback.py
+++ b/mopidy_oe1/playback.py
@@ -16,26 +16,20 @@ class OE1PlaybackProvider(backend.PlaybackProvider):
         super(OE1PlaybackProvider, self).__init__(audio, backend)
         self.client = client
 
-    def change_track(self, track):
+    def translate_uri(self, uri):
         try:
-            library_uri = OE1LibraryUri.parse(track.uri)
+            library_uri = OE1LibraryUri.parse(uri)
         except InvalidOE1Uri:
-            return False
+            return None
 
         if library_uri.uri_type == OE1UriType.LIVE:
-            track = track.copy(uri=OE1Client.LIVE)
-            return super(OE1PlaybackProvider, self).change_track(track)
+            return OE1Client.LIVE
 
         if library_uri.uri_type == OE1UriType.CAMPUS:
-            track = track.copy(uri=OE1Client.CAMPUS)
-            return super(OE1PlaybackProvider, self).change_track(track)
+            return OE1Client.CAMPUS
 
         if library_uri.uri_type == OE1UriType.ARCHIVE_ITEM:
             item = self.client.get_item(library_uri.day_id,
                                         library_uri.item_id)
-            if item is None:
-                return False
-            track = track.copy(uri=item['url'])
-            return super(OE1PlaybackProvider, self).change_track(track)
-
-        return False
+            if item is not None:
+                return item['url']

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'simplejson',
         'beaker',
-        'Mopidy >= 0.18',
+        'Mopidy >= 1.0',
         'Pykka >= 1.1',
     ],
     test_suite='nose.collector',

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -4,8 +4,6 @@ import unittest
 
 from mock import Mock
 
-from mopidy.models import Track
-
 from mopidy_oe1.client import OE1Client
 from mopidy_oe1.playback import OE1LibraryUri, OE1PlaybackProvider, OE1UriType
 
@@ -14,70 +12,43 @@ class OE1LibraryUriTest(unittest.TestCase):
     def test_playback_archive_item(self):
         library_uri = OE1LibraryUri(OE1UriType.ARCHIVE_ITEM,
                                     '20140914', '1234567')
-        track = Track(uri=str(library_uri))
-
         client_mock = Mock()
         client_mock.get_item = Mock(return_value={'url': 'result_uri'})
+        playback = OE1PlaybackProvider(None, None, client=client_mock)
 
-        audio_mock = Mock()
-        audio_mock.set_uri = Mock()
+        result = playback.translate_uri(str(library_uri))
 
-        playback = OE1PlaybackProvider(audio_mock, None, client=client_mock)
-        result = playback.change_track(track)
-
-        self.assertTrue(result)
-        self.assertEqual(audio_mock.set_uri.call_count, 1)
-        self.assertEqual(audio_mock.set_uri.call_args[0][0], 'result_uri')
+        self.assertEqual(result, 'result_uri')
 
     def test_playback_live(self):
         library_uri = OE1LibraryUri(OE1UriType.LIVE)
-        track = Track(uri=str(library_uri))
+        playback = OE1PlaybackProvider(None, None, client=None)
 
-        audio_mock = Mock()
-        audio_mock.set_uri = Mock()
+        result = playback.translate_uri(str(library_uri))
 
-        playback = OE1PlaybackProvider(audio_mock, None, client=None)
-        result = playback.change_track(track)
-
-        self.assertTrue(result)
-        self.assertEqual(audio_mock.set_uri.call_count, 1)
-        self.assertEqual(audio_mock.set_uri.call_args[0][0], OE1Client.LIVE)
+        self.assertEqual(result, OE1Client.LIVE)
 
     def test_playback_campus(self):
         library_uri = OE1LibraryUri(OE1UriType.CAMPUS)
-        track = Track(uri=str(library_uri))
+        playback = OE1PlaybackProvider(None, None, client=None)
 
-        audio_mock = Mock()
-        audio_mock.set_uri = Mock()
+        result = playback.translate_uri(str(library_uri))
 
-        playback = OE1PlaybackProvider(audio_mock, None, client=None)
-        result = playback.change_track(track)
-
-        self.assertTrue(result)
-        self.assertEqual(audio_mock.set_uri.call_count, 1)
-        self.assertEqual(audio_mock.set_uri.call_args[0][0], OE1Client.CAMPUS)
+        self.assertEqual(result, OE1Client.CAMPUS)
 
     def test_playback_invalid_url(self):
-        track = Track(uri='invalid')
-
         audio_mock = Mock()
         audio_mock.set_uri = Mock()
 
         playback = OE1PlaybackProvider(audio_mock, None, client=None)
-        result = playback.change_track(track)
+        result = playback.translate_uri('invalid')
 
-        self.assertFalse(result)
-        self.assertEqual(audio_mock.set_uri.call_count, 0)
+        self.assertIsNone(result)
 
     def test_playback_unplayable_url(self):
         library_uri = OE1LibraryUri(OE1UriType.ARCHIVE)
-        track = Track(uri=str(library_uri))
+        playback = OE1PlaybackProvider(None, None, client=None)
 
-        audio_mock = Mock()
-        audio_mock.set_uri = Mock()
+        result = playback.translate_uri(str(library_uri))
 
-        playback = OE1PlaybackProvider(audio_mock, None, client=None)
-        result = playback.change_track(track)
-
-        self.assertFalse(result)
-        self.assertEqual(audio_mock.set_uri.call_count, 0)
+        self.assertIsNone(result)


### PR DESCRIPTION
Mopidy 1.0 has been released. This is an untested shot at getting Mopidy-OE1 working with the changed backend APIs in Mopidy 1.0.

See https://docs.mopidy.com/en/latest/changelog/#v1-0-0-2015-03-25 for details
