### PR TITLE
Port to Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
 language: python
 
 python:
-  - "2.7_with_system_site_packages"
+  - "3.7"
 
 env:
-  - TOX_ENV=py27
+  - TOX_ENV=py37
   - TOX_ENV=flake8
 
 install:
-  - "wget -O - http://apt.mopidy.com/mopidy.gpg | sudo apt-key add -"
-  - "sudo wget -O /etc/apt/sources.list.d/mopidy.list http://apt.mopidy.com/mopidy.list"
-  - "sudo apt-get update || true"
-  - "sudo apt-get install mopidy"
   - "pip install tox"
 
 script:
   - "tox -e $TOX_ENV"
 
 after_success:
-  - "if [ $TOX_ENV == 'py27' ]; then pip install coveralls; coveralls; fi"
+  - "if [ $TOX_ENV == 'py37' ]; then pip install coveralls; coveralls; fi"
 

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,10 @@ Project resources
 Changelog
 =========
 
+v2.0.0 (2019-12-08)
+-------------------
+- Ported to Python 3 (Tobias Girstmair `girst <https://gir.st/>`_)
+
 v1.2.0 (2017-06-11)
 -------------------
 - Update live stream URLs

--- a/mopidy_oe1/__init__.py
+++ b/mopidy_oe1/__init__.py
@@ -6,7 +6,7 @@ import os
 from mopidy import config, ext
 
 
-__version__ = '1.2.0'
+__version__ = '2.0.0'
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy_oe1/client.py
+++ b/mopidy_oe1/client.py
@@ -1,8 +1,5 @@
-from __future__ import unicode_literals
-
-
 import logging
-import urllib2
+import urllib
 
 from beaker.cache import CacheManager
 from beaker.util import parse_cache_config_options
@@ -25,11 +22,11 @@ class HttpClient(object):
     def get(self, url):
         try:
             logger.info('Fetching data from \'%s\'.', url)
-            response = urllib2.urlopen(url)
+            response = urllib.request.urlopen(url)
             content = response.read()
             encoding = response.headers['content-type'].split('charset')[-1]
-            return unicode(content, encoding)
-        except Exception, e:
+            return content.decode(encoding)
+        except Exception as e:
             logger.error('Error fetching data from \'%s\': %s', url, e)
 
     def refresh(self):
@@ -109,7 +106,7 @@ class OE1Client(object):
             content = self.http_client.get(uri)
             decoder = simplejson.JSONDecoder()
             return decoder.decode(content)
-        except Exception, e:
+        except Exception as e:
             logger.error('Error decoding content received from \'%s\': %s',
                          uri, e)
 

--- a/mopidy_oe1/library.py
+++ b/mopidy_oe1/library.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 import logging
 import re
 
-from client import OE1Client
-
 from mopidy import backend
 from mopidy.models import Ref, Track
+
+from .client import OE1Client
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class OE1LibraryProvider(backend.LibraryProvider):
     def browse(self, uri):
         try:
             library_uri = OE1LibraryUri.parse(uri)
-        except InvalidOE1Uri, e:
+        except InvalidOE1Uri as e:
             logger.error(e)
             return []
 
@@ -45,8 +45,8 @@ class OE1LibraryProvider(backend.LibraryProvider):
         if library_uri.uri_type == OE1UriType.ARCHIVE_DAY:
             return self._browse_day(library_uri.day_id)
 
-        logger.warn('OE1LibraryProvider.browse called with uri '
-                    'that does not support browsing: \'%s\'.' % uri)
+        logger.warning('OE1LibraryProvider.browse called with uri '
+                       'that does not support browsing: \'%s\'.' % uri)
         return []
 
     def _browse_archive(self):
@@ -67,7 +67,7 @@ class OE1LibraryProvider(backend.LibraryProvider):
     def lookup(self, uri):
         try:
             library_uri = OE1LibraryUri.parse(uri)
-        except InvalidOE1Uri, e:
+        except InvalidOE1Uri as e:
             logger.error(e)
             return []
 
@@ -83,8 +83,8 @@ class OE1LibraryProvider(backend.LibraryProvider):
         if library_uri.uri_type == OE1UriType.ARCHIVE_ITEM:
             return self._lookup_item(library_uri.day_id, library_uri.item_id)
 
-        logger.warn('OE1LibraryProvider.lookup called with uri '
-                    'that does not support lookup: \'%s\'.' % uri)
+        logger.warning('OE1LibraryProvider.lookup called with uri '
+                       'that does not support lookup: \'%s\'.' % uri)
         return []
 
     def _lookup_item(self, day_id, item_id):
@@ -103,8 +103,8 @@ class OE1LibraryUri(object):
         self.day_id = day_id
         self.item_id = item_id
 
-    archive_parse_expression = '^' + re.escape(OE1Uris.ARCHIVE) +\
-                               ':(?P<day_id>\d{8})(:(?P<item_id>\d+))?$'
+    archive_parse_expression = r'^' + re.escape(OE1Uris.ARCHIVE) +\
+                               r':(?P<day_id>\d{8})(:(?P<item_id>\d+))?$'
     archive_parser = re.compile(archive_parse_expression)
 
     @staticmethod

--- a/mopidy_oe1/playback.py
+++ b/mopidy_oe1/playback.py
@@ -2,11 +2,11 @@ from __future__ import unicode_literals
 
 import logging
 
-from client import OE1Client
-
 from mopidy import backend
 
 from mopidy_oe1.library import InvalidOE1Uri, OE1LibraryUri, OE1UriType
+
+from .client import OE1Client
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,9 +2,9 @@ from __future__ import unicode_literals
 
 import unittest
 
-import utils
-
 from mopidy_oe1.client import OE1Client
+
+from . import utils
 
 
 class OE1ClientTest(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, flake8
+envlist = py37, flake8
 
 [testenv]
 sitepackages = true
@@ -7,10 +7,9 @@ deps =
     coverage
     mock
     nose
-    mopidy
-    gi
+    mopidy>=3.0.0a6
     python-dateutil
-install_command = pip install --allow-unverified=mopidy --pre {opts} {packages}
+install_command = pip install --pre {opts} {packages}
 commands = nosetests -v --with-xunit --xunit-file=xunit-{envname}.xml --with-coverage --cover-package=mopidy_oe1 --exe -w tests
 
 [testenv:flake8]


### PR DESCRIPTION
The next version of Mopidy (3.0) will only support python3.

I've taken the liberty of pushing the version of this extension to 2.0.0 to mark its incompatibility with python2, as well as updating the changelog. feel free to change anything to suit you.